### PR TITLE
Fix parallax ypos assignment

### DIFF
--- a/BinaryLensBinarySourceFitter/__init__.py
+++ b/BinaryLensBinarySourceFitter/__init__.py
@@ -262,7 +262,7 @@ class Binary_lens_Binary_source_mcmc():
 	
 		# Earth position at perihelion?
 		self.parallax_xpos = self.primary.parallax_xpos
-		self.parallax_ypos = self.primary.parallax_xpos
+                self.parallax_ypos = self.primary.parallax_ypos
 
 		# Galactic rotation
 		self.galaxy_rotation_direction = self.primary.galaxy_rotation_direction


### PR DESCRIPTION
## Summary
- fix parallax `y` component to copy from primary model

## Testing
- `pytest -q` *(no tests found)*
- `python - <<'PY' ...` *(fails: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_683f68455b9c8328adabc5028eb77498