### PR TITLE
Rename gaussian process bounds function

### DIFF
--- a/BinaryLensFitter/__init__.py
+++ b/BinaryLensFitter/__init__.py
@@ -62,7 +62,7 @@ class Binary_lens_mcmc():
 	from ._galactic import add_galactic_prior, galactic_ln_prior_prob, neg_skew_pdf, fit_skew_normal, fit_log_skew_normal, set_skew_parameters, skewnormal_prior
 	
 	from ._gaussian_process import add_gaussian_process_model, gaussian_process_prior, gaussian_process_ground_chi2, \
-				gaussian_process_spitzer_chi2, CeleriteModel, get_gaussian_proceess_bounds
+				gaussian_process_spitzer_chi2, CeleriteModel, get_gaussian_process_bounds
 
 	from ._VBBL import VBBL_magnification
 

--- a/BinaryLensFitter/_gaussian_process.py
+++ b/BinaryLensFitter/_gaussian_process.py
@@ -136,7 +136,7 @@ def gaussian_process_prior(self, p):
 	    return -np.inf
 	
 	
-def get_gaussian_proceess_bounds(self):
+def get_gaussian_process_bounds(self):
 
     bounds = []
 


### PR DESCRIPTION
## Summary
- rename `get_gaussian_proceess_bounds` to `get_gaussian_process_bounds`
- update imports accordingly

## Testing
- `python -m py_compile BinaryLensFitter/__init__.py BinaryLensFitter/_gaussian_process.py`

------
https://chatgpt.com/codex/tasks/task_e_683f6ce870ec8328b91c14c44b75088e