### PR TITLE
Fix source default handling

### DIFF
--- a/BinaryLensBinarySourceFitter/_likelihood.py
+++ b/BinaryLensBinarySourceFitter/_likelihood.py
@@ -1,9 +1,12 @@
 import numpy as np
 import sys
 
-def chi2_calc(self, p_in=None, source=[], use_spitzer_only=False, compute_uncertainties=False):
+def chi2_calc(self, p_in=None, source=None, use_spitzer_only=False, compute_uncertainties=False):
 
 	"""Compute chi^2 for all data sources or for a single source."""
+
+	if source is None:
+		source = []
 
 	if p_in is None:
 		p_in = self.p.copy()

--- a/BinaryLensFitter/_likelihood.py
+++ b/BinaryLensFitter/_likelihood.py
@@ -1,10 +1,12 @@
 import numpy as np
 import sys
 
-def chi2_calc(self, p_in=None, source=[], use_spitzer_only=False, compute_uncertainties=False):
+def chi2_calc(self, p_in=None, source=None, use_spitzer_only=False, compute_uncertainties=False):
 
 	"""Compute chi^2 for all data sources or for a single source."""
 
+	if source is None:
+		source = []
 	if p_in is None:
 		p_in = self.p.copy()
 


### PR DESCRIPTION
## Summary
- allow `None` for `source` parameter in likelihood calculations
- normalize `source` to an empty list inside the functions

## Testing
- `python -m py_compile BinaryLensFitter/_likelihood.py BinaryLensBinarySourceFitter/_likelihood.py`

------
https://chatgpt.com/codex/tasks/task_e_683f6e4454ec832886e4cb9ba987d998