### PR TITLE
Fix type check in Gaussian process setup

### DIFF
--- a/BinaryLensFitter/_gaussian_process.py
+++ b/BinaryLensFitter/_gaussian_process.py
@@ -18,7 +18,7 @@ def add_gaussian_process_model(self,common=True, sites=None, model=None, default
         self.GP_default_params = default_params
     if sig0 is not None:
         self.GP_sig0 = sig0
-    if type(sites) == type('string'):
+    if isinstance(sites, str):
         self.gaussian_process_sites = [sites]
     elif sites is not None:
         self.gaussian_process_sites = sites	


### PR DESCRIPTION
## Summary
- clarify type check for `sites` when setting up a Gaussian process by using `isinstance`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f6fe6488c83288d94e924a0f927c0